### PR TITLE
Fix for changed command-line options

### DIFF
--- a/ink2pdf
+++ b/ink2pdf
@@ -76,6 +76,11 @@ if ($BGLAYER) {
     }
 }
 
+# Option for PDF output was changed in 1.x
+`inkscape --version 2> /dev/null` =~ /(\d+)\.(\d+)\.(\d+)/
+    or die "*** Cannot determine inkscape version";
+my $inkscape_options = $1 == 0 ? "-z -A " : "--export-filename=";
+
 # Generate the PDF's
 $XMODE
     ? do_by_prefix()
@@ -277,7 +282,7 @@ sub generate_all {
 sub generate_pdf {
     my $inkfile = shift;
     my $outfile = shift;
-    system("inkscape -z -A '$outfile' '$inkfile' 2>/dev/null") == 0
+    system("inkscape $inkscape_options'$outfile' '$inkfile' 2>/dev/null") == 0
         or die "*** inkscape command failure\n";
 }
 

--- a/ink2pdf
+++ b/ink2pdf
@@ -76,9 +76,14 @@ if ($BGLAYER) {
     }
 }
 
+# Verbosity should affect inkscape stderr, too
+my $inkscape_stderr = $VERBOSE == 2 ? "" : "2>/dev/null";
+
 # Option for PDF output was changed in 1.x
-`inkscape --version 2> /dev/null` =~ /(\d+)\.(\d+)\.(\d+)/
-    or die "*** Cannot determine inkscape version";
+my $inkscape_version = `inkscape --version $inkscape_stderr`;
+$inkscape_version =~ /(\d+)\.(\d+)\.(\d+)/
+    or die "*** Cannot determine inkscape version from '$inkscape_version'";
+print $inkscape_version if $VERBOSE == 2;
 my $inkscape_options = $1 == 0 ? "-z -A " : "--export-filename=";
 
 # Generate the PDF's
@@ -282,7 +287,7 @@ sub generate_all {
 sub generate_pdf {
     my $inkfile = shift;
     my $outfile = shift;
-    system("inkscape $inkscape_options'$outfile' '$inkfile' 2>/dev/null") == 0
+    system("inkscape $inkscape_options'$outfile' '$inkfile' $inkscape_stderr") == 0
         or die "*** inkscape command failure\n";
 }
 


### PR DESCRIPTION
It seems that with the move to version 1.x, inkscape's command-line options were overhauled. Your script dies without any indication of what the problem might be. Executing the command manually yields
```
Warning: Option --without-gui= is deprecated
Unknown option -A
```
One solution that ensures backwards compatibility is to check inkscape's version string and choose the command line options appropriately. I'm not entirely sure that my method is robust, but it was tested on Ubuntu 18.04 (`Inkscape 0.92.3 (2405546, 2018-03-11)`) and Fedora 33 (`Inkscape 1.0.1 (3bc2e813f5, 2020-09-07)`) and is working as expected.